### PR TITLE
SLURM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .venv
 *.bak
 checkpoints/
+runs/
 data/mnist/
 data/cifar10/
 data/retinopathy

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ wget 'https://storage.googleapis.com/kaggle-forum-message-attachments/90528/2877
 
 ## Commands
 (You might need to add `--extra cpu` after `uv run` to avoid downloading CUDA).
-* Training: `uv run src/prox_lora/train.py`
+* Training: `uv run src/prox_lora/train.py --help`
+* For example, to submit a small training job to SLURM:
+    `uv run src/prox_lora/train.py submit mnist_example --replace trainer.max_epochs 1 --follow`
 
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "transformers>=4.55",
     "tqdm",
     "typing-extensions",
+    "tyro>=1.0.13",
 ]
 
 

--- a/src/prox_lora/infrastructure/cli.py
+++ b/src/prox_lora/infrastructure/cli.py
@@ -30,7 +30,6 @@ class CLI:
     def run(self) -> None:
         self.before_main()
         self.main()
-        self.after_main()
 
     def before_main(self) -> None:
         dotenv.load_dotenv()
@@ -39,9 +38,6 @@ class CLI:
         _silence_spurious_warnings()
         if not self.skip_torch:
             _setup_torch()
-
-    def after_main(self) -> None:
-        print("Finished.")
 
 
 def seed_everything(seed: int, *, skip_torch: bool = False) -> None:

--- a/src/prox_lora/infrastructure/cli.py
+++ b/src/prox_lora/infrastructure/cli.py
@@ -23,9 +23,8 @@ class CLI:
     - skip_torch: if True, don't import and initialize torch and Lightning (which takes a few seconds).
     """
 
-    def __init__(self, main: Callable[[], None], seed: int, *, skip_torch: bool = False) -> None:
+    def __init__(self, main: Callable[[], None], *, skip_torch: bool = False) -> None:
         self.main = main
-        self.seed = seed
         self.skip_torch = skip_torch
 
     def run(self) -> None:
@@ -38,25 +37,29 @@ class CLI:
 
         _setup_sigusr_handlers()
         _silence_spurious_warnings()
-
-        # Seed like `lightning.fabric.utilities.seed.seed_everything`, without importing it.
-        os.environ["PL_GLOBAL_SEED"] = str(self.seed)
-        os.environ["PL_SEED_WORKERS"] = "1"
-        random.seed(self.seed)
-        np.random.seed(self.seed)  # noqa: NPY002
-
         if not self.skip_torch:
-            _setup_torch(self.seed)
+            _setup_torch()
 
     def after_main(self) -> None:
         print("Finished.")
 
 
-def _setup_torch(seed: int) -> None:
+def seed_everything(seed: int, *, skip_torch: bool = False) -> None:
+    """Seed like `lightning.fabric.utilities.seed.seed_everything`, without importing it."""
+    os.environ["PL_GLOBAL_SEED"] = str(seed)
+    os.environ["PL_SEED_WORKERS"] = "1"
+    random.seed(seed)
+    np.random.seed(seed)  # noqa: NPY002
+
+    if not skip_torch:
+        import torch  # noqa: PLC0415
+
+        torch.manual_seed(seed)
+
+
+def _setup_torch() -> None:
     """Setup torch compute precision options (and some printing options too)."""
     import torch  # noqa: PLC0415
-
-    torch.manual_seed(seed)
 
     torch.set_printoptions(precision=2, threshold=6, edgeitems=3, linewidth=200)  # type: ignore[no-untyped-call]
 

--- a/src/prox_lora/infrastructure/slurm.py
+++ b/src/prox_lora/infrastructure/slurm.py
@@ -35,6 +35,9 @@ def submit_slurm_job(
 
     if not follow:
         print(f"To follow logs:\n    tail -f {log_path}\nTo cancel (kill) job:\n    scancel {job_id}")
+        print(
+            f"To check job status:\n  squeue -j {job_id} --Format=jobid:10,username:20,name:40,partition:8,submittime,timeleft:16,state:10,reason:20,nodelist,tres-alloc:60"
+        )
         print(f"To run something within the same allocation:\n    srun --jobid={job_id} --overlap --pty /bin/bash -i")
         return
 
@@ -88,6 +91,7 @@ def make_sbatch_script(slurm_config: SlurmConfig, job_name: str, log_path: Path,
     script = "#!/bin/bash\n"
     for arg in sbatch_args:
         script += f"#SBATCH {arg}\n"
-    script += "\nset -euxo pipefail\nexport PYTHONUNBUFFERED=1\n\n"
+    script += "\nset -euxo pipefail\nexport PYTHONUNBUFFERED=1\n"
+    script += 'echo "Running on node: $(hostname)"\n\n'
     script += job_cmd + "\n"
     return script

--- a/src/prox_lora/infrastructure/slurm.py
+++ b/src/prox_lora/infrastructure/slurm.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,9 +18,56 @@ class SlurmConfig:
     mail: str | None = None
 
 
-def submit_slurm_job(slurm_config: SlurmConfig, job_name: str, log_path: Path, job_args: list[str | Path]) -> None:
-    args = [
-        "sbatch",
+def submit_slurm_job(
+    slurm_config: SlurmConfig, job_name: str, run_dir: Path, job_args: list[str | Path], *, follow: bool = True
+) -> None:
+    log_path = run_dir / "log.txt"
+    script_path = run_dir / "sbatch.sh"
+
+    args = [str(arg.absolute()) if isinstance(arg, Path) else arg for arg in job_args]
+    script_path.write_text(make_sbatch_script(slurm_config, job_name, log_path, shlex.join(args)))
+
+    r = subprocess.run(["sbatch", "--parsable", str(script_path)], check=True, capture_output=True)
+
+    job_id = r.stdout.decode().strip()
+    print(f"Submitted SLURM job with ID: {job_id}.")
+    (run_dir / f"slurm_job_{job_id}").touch()
+
+    if not follow:
+        print(f"To follow logs:\n    tail -f {log_path}\nTo cancel (kill) job:\n    scancel {job_id}")
+        print(f"To run something within the same allocation:\n    srun --jobid={job_id} --overlap --pty /bin/bash -i")
+        return
+
+    try:
+        subprocess.run(
+            r"""
+                while [ ! -f {log_path} ]; do
+                    clear
+                    echo "Waiting for job" {job_id} "to start before showing logs... (press Ctrl+C to stop following, the job will not be cancelled)"
+                    echo "To cancel job:\n    scancel" {job_id} "\n\n"
+                    squeue --Format=jobid:10,username:20,name:40,partition:8,submittime,timeleft:16,state:10,reason:20,nodelist,tres-alloc:60 --partition={partition}
+                    sleep 1
+                done
+                clear
+                echo "Following logs for job" {job_id} "... (press Ctrl+C to stop following, the job will continue running)"
+                echo "To cancel (kill) job:\n    scancel" {job_id}
+                echo "To run something within the same allocation:\n    srun --jobid="{job_id}" --overlap --pty /bin/bash -i\n\n"
+                tail -f {log_path}
+            """.format(
+                log_path=shlex.quote(str(log_path.absolute())),
+                job_id=shlex.quote(job_id),
+                partition=shlex.quote(slurm_config.partition),
+            ),
+            shell=True,
+            check=False,
+        )
+    except KeyboardInterrupt:
+        print(f"\n\n\nTo follow again:\n    tail -f {log_path}\nTo cancel (kill) job:\n    scancel {job_id}")
+        return
+
+
+def make_sbatch_script(slurm_config: SlurmConfig, job_name: str, log_path: Path, job_cmd: str) -> str:
+    sbatch_args = [
         f"--chdir={PROJECT_ROOT}",
         f"--time={slurm_config.duration}",
         f"--partition={slurm_config.partition}",
@@ -29,19 +77,17 @@ def submit_slurm_job(slurm_config: SlurmConfig, job_name: str, log_path: Path, j
         f"--error={log_path.absolute()}",
     ]
     if slurm_config.mem is not None:
-        args += ["--mem", slurm_config.mem]
+        sbatch_args += ["--mem", slurm_config.mem]
     if slurm_config.cpus is not None:
-        args += ["--cpus-per-task", str(slurm_config.cpus)]
+        sbatch_args += ["--cpus-per-task", str(slurm_config.cpus)]
     if slurm_config.gpus > 0:
-        args += ["--gpus-per-node", str(slurm_config.gpus)]
+        sbatch_args += ["--gpus-per-node", str(slurm_config.gpus)]
     if slurm_config.mail is not None:
-        args += ["--mail-user", slurm_config.mail, "--mail-type=ALL"]
+        sbatch_args += ["--mail-user", slurm_config.mail, "--mail-type=ALL"]
 
-    args += ["srun"]
-    args += [str(arg.absolute()) if isinstance(arg, Path) else arg for arg in job_args]
-
-    r = subprocess.run(args, check=True, capture_output=True)
-    job_id = r.stdout.decode().strip()
-    print(f"Submitted SLURM job with ID: {job_id}.")
-    (log_path.parent / f"slurm_job_{job_id}").touch()
-    # TODO start monitoring logs by default.
+    script = "#!/bin/bash\n"
+    for arg in sbatch_args:
+        script += f"#SBATCH {arg}\n"
+    script += "\nset -euxo pipefail\n\n"
+    script += job_cmd + "\n"
+    return script

--- a/src/prox_lora/infrastructure/slurm.py
+++ b/src/prox_lora/infrastructure/slurm.py
@@ -88,6 +88,6 @@ def make_sbatch_script(slurm_config: SlurmConfig, job_name: str, log_path: Path,
     script = "#!/bin/bash\n"
     for arg in sbatch_args:
         script += f"#SBATCH {arg}\n"
-    script += "\nset -euxo pipefail\n\n"
+    script += "\nset -euxo pipefail\nexport PYTHONUNBUFFERED=1\n\n"
     script += job_cmd + "\n"
     return script

--- a/src/prox_lora/infrastructure/slurm.py
+++ b/src/prox_lora/infrastructure/slurm.py
@@ -1,0 +1,47 @@
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from prox_lora.infrastructure.configs import yaml
+from prox_lora.utils.io import PROJECT_ROOT
+
+
+@yaml.register_class
+@dataclass(frozen=True)
+class SlurmConfig:
+    duration: str = "00:10:00"  # Duration in format "DD-HH:MM:SS" or smaller parts like "MM:SS"
+    partition: str = "common"
+    mem: str | None = None  # like "16G" for GiB.
+    cpus: int | None = None
+    gpus: int = 1
+    mail: str | None = None
+
+
+def submit_slurm_job(slurm_config: SlurmConfig, job_name: str, log_path: Path, job_args: list[str | Path]) -> None:
+    args = [
+        "sbatch",
+        f"--chdir={PROJECT_ROOT}",
+        f"--time={slurm_config.duration}",
+        f"--partition={slurm_config.partition}",
+        "--ntasks=1",
+        f"--job-name={job_name}",
+        f"--output={log_path.absolute()}",
+        f"--error={log_path.absolute()}",
+    ]
+    if slurm_config.mem is not None:
+        args += ["--mem", slurm_config.mem]
+    if slurm_config.cpus is not None:
+        args += ["--cpus-per-task", str(slurm_config.cpus)]
+    if slurm_config.gpus > 0:
+        args += ["--gpus-per-node", str(slurm_config.gpus)]
+    if slurm_config.mail is not None:
+        args += ["--mail-user", slurm_config.mail, "--mail-type=ALL"]
+
+    args += ["srun"]
+    args += [str(arg.absolute()) if isinstance(arg, Path) else arg for arg in job_args]
+
+    r = subprocess.run(args, check=True, capture_output=True)
+    job_id = r.stdout.decode().strip()
+    print(f"Submitted SLURM job with ID: {job_id}.")
+    (log_path.parent / f"slurm_job_{job_id}").touch()
+    # TODO start monitoring logs by default.

--- a/src/prox_lora/infrastructure/trainer.py
+++ b/src/prox_lora/infrastructure/trainer.py
@@ -1,4 +1,5 @@
 import pprint
+import subprocess
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
@@ -138,9 +139,17 @@ def run_training(
     finally:
         if task is not None:
             print("Flushing ClearML, this may take a while...")
+            # Force kill after 60s in case flush hangs.
+            proc = subprocess.Popen(
+                "sleep 60 && echo 'Hang on ClearML flush, killing...' && kill -2 $PPID "
+                + " && sleep 5 && kill -7 $PPID && sleep 5 && kill -9 $PPID",
+                shell=True,
+            )
             task.flush(wait_for_uploads=True)
             print("Flushed.")
-            # task.close()
+            proc.kill()  # Cancel the backup killer.
+    # if task is not None:
+    #     task.close()
 
 
 def get_new_run_dir(d: Path) -> Path:

--- a/src/prox_lora/infrastructure/trainer.py
+++ b/src/prox_lora/infrastructure/trainer.py
@@ -18,12 +18,12 @@ from prox_lora.datasets.base_data_module import DataLoaderConfig
 from prox_lora.datasets.cifar import CIFAR10Config
 from prox_lora.datasets.diabetic_retinopathy import DRConfig
 from prox_lora.datasets.mnist import MNISTConfig
-from prox_lora.infrastructure.configs import deep_asdict, save_config, yaml
+from prox_lora.infrastructure.cli import seed_everything
+from prox_lora.infrastructure.configs import deep_asdict, yaml
 from prox_lora.models.biomedclip import BiomedCLIPConfig
 from prox_lora.models.classifier import Classifier
 from prox_lora.models.example_cnn import ExampleCNNConfig
 from prox_lora.optimizers.common import OptimizerConfig, SchedulerConfig
-from prox_lora.utils.io import PROJECT_ROOT
 
 
 @yaml.register_class
@@ -60,18 +60,35 @@ class FullTrainConfig:
     )
     scheduler: SchedulerConfig = SchedulerConfig(sched="none")
     trainer: TrainerConfig = TrainerConfig()
-    resume: bool = False
-    clearml: bool = True
+    clearml_project: str | None = "Prox-LoRA"
+    seed: int = 1
 
 
 def run_training(
     config: FullTrainConfig,
+    run_dir: Path,
     model_summary_depth: int = 3,
     metric_for_checkpointing: str = "_loss/val",
-    checkpoint_dir: Path = PROJECT_ROOT / "checkpoints",
     checkpoint_filename_pattern: str = "epoch={epoch:0>3}",
+    *,
+    resume: bool = False,
 ) -> None:
+    """
+    Run training, saving checkpoints and logs under `run_dir`.
+
+    Args:
+    - config: the FullTrainConfig.
+    - run_dir: must be of the form ".../{config.name}/r{number}/".
+    """
+    all_runs_dir = run_dir.parent.parent
+    assert config.name == run_dir.parent.name, f"{config.name=} ≠ {run_dir.parent.name=}"
+    version = run_dir.name
+    assert version.startswith("r"), f"Unexpected {version=}"
+
+    print(f"Training ({resume=}) in run_dir: {run_dir}")
     pprint.pp(config, indent=4, width=200, depth=4, compact=True)
+
+    seed_everything(config.seed)
 
     datamodule = config.datamodule.instantiate(dataloader=config.dataloader)
     datamodule.prepare_data()
@@ -88,14 +105,16 @@ def run_training(
     )
 
     task: clearml.Task | None = None
-    if config.clearml:
-        task = clearml.Task.init(project_name="Prox-LoRA", task_name=config.name)
+    if config.clearml_project is not None:
+        task = clearml.Task.init(
+            project_name=config.clearml_project, task_name=config.name + "/" + version, continue_last_task=resume
+        )
         task.set_parameters_as_dict(deep_asdict(config))
 
     trainer = L.Trainer(
-        default_root_dir=checkpoint_dir / config.name,
+        default_root_dir=all_runs_dir / config.name,
         **asdict(config.trainer),
-        logger=TensorBoardLogger(save_dir=checkpoint_dir, name=config.name, default_hp_metric=False),
+        logger=TensorBoardLogger(save_dir=all_runs_dir, name=config.name, version=version, default_hp_metric=False),
         callbacks=[
             DeviceStatsMonitor(cpu_stats=False),
             LearningRateMonitor(logging_interval="step"),
@@ -105,28 +124,39 @@ def run_training(
                 monitor=metric_for_checkpointing,
                 save_top_k=1,
                 verbose=False,
-                save_last="link",
             ),
+            # Note that using save_last=True or "link" above would only copy or link the last top_k checkpoint.
+            ModelCheckpoint(filename="last", auto_insert_metric_name=False, verbose=False),
             RichProgressBar(leave=True, console_kwargs=dict(force_terminal=True, force_interactive=True, width=250)),
             RichModelSummary(max_depth=model_summary_depth),
         ],
         enable_model_summary=False,  # Disable default model summary in favor of RichModelSummary.
     )
 
-    if trainer.logger:
-        assert trainer.logger.log_dir is not None
-        version_dir = Path(trainer.logger.log_dir)
-        version_dir.mkdir(parents=True, exist_ok=True)
-        save_config(config, version_dir / "config.yaml")
-
     try:
-        if config.resume:
-            trainer.fit(classifier, datamodule, ckpt_path="last")
-        else:
-            trainer.fit(classifier, datamodule)
+        trainer.fit(classifier, datamodule, ckpt_path="last" if resume else None)
     finally:
         if task is not None:
             print("Flushing ClearML, this may take a while...")
             task.flush(wait_for_uploads=True)
             print("Flushed.")
             # task.close()
+
+
+def get_new_run_dir(d: Path) -> Path:
+    """Create a new run directory under `d`, like "r0" or "r1", with an auto-incremented version number."""
+    d.mkdir(parents=True, exist_ok=True)
+    versions = []
+    for p in d.iterdir():
+        if p.name.startswith("r"):
+            try:
+                versions.append(int(p.name[1:]))
+            except ValueError:  # Ignore directories that don't follow the "r{number}" pattern.
+                pass
+    next = max(versions, default=0) + 1
+    run_dir = d / f"r{next}"
+    try:
+        run_dir.mkdir()
+    except FileExistsError:
+        raise ValueError(f"Run directory {run_dir} already exists (race condition?)") from None
+    return run_dir

--- a/src/prox_lora/train.py
+++ b/src/prox_lora/train.py
@@ -1,22 +1,95 @@
+"""Run with `uv run src/prox_lora/train.py --help`."""
+
+from pathlib import Path
+
+import tyro
+
 from prox_lora.infrastructure.cli import CLI
-from prox_lora.infrastructure.configs import deep_replace, get_config
-from prox_lora.infrastructure.trainer import FullTrainConfig, run_training
+from prox_lora.infrastructure.configs import deep_replace, get_config, load_config, save_config
+from prox_lora.infrastructure.slurm import SlurmConfig, submit_slurm_job
+from prox_lora.infrastructure.trainer import FullTrainConfig, get_new_run_dir, run_training
 from prox_lora.utils.io import PROJECT_ROOT
 
+DEFAULT_SLURM_CONFIG = SlurmConfig(duration="00:10:00", partition="common", mem="2G", cpus=2, gpus=1)
 
 def main() -> None:
-    config = get_config(FullTrainConfig, "mnist_example_ISTA")
-    config = deep_replace(
-        config,
+    tyro.extras.subcommand_cli_from_dict(
+        {
+            "example": example,
+            "start": start_training,
+            "resume": resume_training,
+            "submit": submit_training,
+            "submit-resume": submit_resume_training,
+        }
+    )
+
+
+def example() -> None:
+    start_training(
+        "mnist_example_ISTA",
         {
             # "name": "mnist-april",
-            # "dataloader.pin_memory": False,
-            # "clearml": False,
-            # "resume": True,
+            "dataloader.pin_memory": False
+            # "clearml_project": None,
         },
     )
-    run_training(config, checkpoint_dir=PROJECT_ROOT / "checkpoints")
+
+
+def start_training(config: str, /, replace: dict[str, bool | int | float | str] | None = None) -> None:
+    """
+    Run a new training.
+
+    Example:
+    ```
+        train.py start mnist_example_ISTA --replace dataloader.pin_memory False optimizer.lr 0.01
+    ```
+
+    Args:
+        config: Name of a registered FullTrainConfig, like "mnist_example_ISTA".
+        replace: Quick replacements for FullTrainConfig values.
+    """
+    cfg = get_config(FullTrainConfig, config)
+    cfg = deep_replace(cfg, replace or {})
+    run_dir = get_new_run_dir(PROJECT_ROOT / "runs" / cfg.name)
+    save_config(cfg, run_dir / "config.yaml")
+    run_training(cfg, run_dir=run_dir, resume=False)
+
+
+def resume_training(run_dir: Path, /) -> None:
+    """Resume training from a run directory containing a config.yaml."""
+    if not (run_dir / "config.yaml").exists():
+        raise ValueError(f"Run directory {run_dir} should contain config.yaml.")
+    cfg: FullTrainConfig = load_config(run_dir / "config.yaml")
+    run_training(cfg, run_dir=run_dir.absolute(), resume=True)
+
+
+def submit_training(
+    config: str, /, replace: dict[str, bool | int | float | str] | None = None, slurm: SlurmConfig = DEFAULT_SLURM_CONFIG
+) -> None:
+    """Submit a new training job via SLURM."""
+    cfg = get_config(FullTrainConfig, config)
+    cfg = deep_replace(cfg, replace or {})
+
+    run_dir = get_new_run_dir(PROJECT_ROOT / "runs" / cfg.name)
+    save_config(cfg, run_dir / "config.yaml")
+    save_config(slurm, run_dir / "slurm_config.yaml")
+
+    submit_slurm_job(
+        slurm,
+        job_name=cfg.name + "/" + run_dir.name,
+        log_path=run_dir / "log.txt",
+        job_args=["uv", "run", PROJECT_ROOT / "src" / "prox_lora" / "train.py", "resume", run_dir],
+    )
+
+
+def submit_resume_training(run_dir: Path, /, slurm: SlurmConfig = DEFAULT_SLURM_CONFIG) -> None:
+    submit_slurm_job(
+        slurm,
+        job_name=run_dir.parent.name + "/" + run_dir.name,
+        log_path=run_dir / "log.txt",
+        job_args=["uv", "run", PROJECT_ROOT / "src" / "prox_lora" / "train.py", "resume", run_dir],
+    )
 
 
 if __name__ == "__main__":
-    CLI(main, seed=42).run()
+    CLI(main).run()

--- a/src/prox_lora/train.py
+++ b/src/prox_lora/train.py
@@ -10,7 +10,8 @@ from prox_lora.infrastructure.slurm import SlurmConfig, submit_slurm_job
 from prox_lora.infrastructure.trainer import FullTrainConfig, get_new_run_dir, run_training
 from prox_lora.utils.io import PROJECT_ROOT
 
-DEFAULT_SLURM_CONFIG = SlurmConfig(duration="00:10:00", partition="common", mem="2G", cpus=2, gpus=1)
+DEFAULT_SLURM_CONFIG = SlurmConfig(duration="00:10:00", partition="common", gpus=1)
+
 
 def main() -> None:
     tyro.extras.subcommand_cli_from_dict(
@@ -53,6 +54,7 @@ def start_training(config: str, /, replace: dict[str, bool | int | float | str] 
     run_dir = get_new_run_dir(PROJECT_ROOT / "runs" / cfg.name)
     save_config(cfg, run_dir / "config.yaml")
     run_training(cfg, run_dir=run_dir, resume=False)
+    print("Training finished.")
 
 
 def resume_training(run_dir: Path, /) -> None:
@@ -60,11 +62,18 @@ def resume_training(run_dir: Path, /) -> None:
     if not (run_dir / "config.yaml").exists():
         raise ValueError(f"Run directory {run_dir} should contain config.yaml.")
     cfg: FullTrainConfig = load_config(run_dir / "config.yaml")
-    run_training(cfg, run_dir=run_dir.absolute(), resume=True)
+    resume = (run_dir / "checkpoints").exists()
+    run_training(cfg, run_dir=run_dir.absolute(), resume=resume)
+    print("Training finished.")
 
 
 def submit_training(
-    config: str, /, replace: dict[str, bool | int | float | str] | None = None, slurm: SlurmConfig = DEFAULT_SLURM_CONFIG
+    config: str,
+    /,
+    replace: dict[str, bool | int | float | str] | None = None,
+    slurm: SlurmConfig = DEFAULT_SLURM_CONFIG,
+    *,
+    follow: bool = False,
 ) -> None:
     """Submit a new training job via SLURM."""
     cfg = get_config(FullTrainConfig, config)
@@ -72,22 +81,26 @@ def submit_training(
 
     run_dir = get_new_run_dir(PROJECT_ROOT / "runs" / cfg.name)
     save_config(cfg, run_dir / "config.yaml")
-    save_config(slurm, run_dir / "slurm_config.yaml")
 
     submit_slurm_job(
         slurm,
         job_name=cfg.name + "/" + run_dir.name,
-        log_path=run_dir / "log.txt",
+        run_dir=run_dir,
         job_args=["uv", "run", PROJECT_ROOT / "src" / "prox_lora" / "train.py", "resume", run_dir],
+        follow=follow,
     )
 
 
-def submit_resume_training(run_dir: Path, /, slurm: SlurmConfig = DEFAULT_SLURM_CONFIG) -> None:
+def submit_resume_training(
+    run_dir: Path, /, slurm: SlurmConfig = DEFAULT_SLURM_CONFIG, *, follow: bool = False
+) -> None:
+    """Submit a SLURM job to resume some training."""
     submit_slurm_job(
         slurm,
         job_name=run_dir.parent.name + "/" + run_dir.name,
-        log_path=run_dir / "log.txt",
+        run_dir=run_dir,
         job_args=["uv", "run", PROJECT_ROOT / "src" / "prox_lora" / "train.py", "resume", run_dir],
+        follow=follow,
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -460,6 +460,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "eagerpy"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2270,6 +2279,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "transformers" },
     { name = "typing-extensions" },
+    { name = "tyro" },
 ]
 
 [package.optional-dependencies]
@@ -2340,6 +2350,7 @@ requires-dist = [
     { name = "tqdm" },
     { name = "transformers", specifier = ">=4.55" },
     { name = "typing-extensions" },
+    { name = "tyro", specifier = ">=1.0.13" },
 ]
 provides-extras = ["cpu", "cu128", "cu130"]
 
@@ -3489,6 +3500,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typeguard"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274", size = 80121, upload-time = "2026-02-19T16:09:03.392Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40", size = 36745, upload-time = "2026-02-19T16:09:01.6Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3564,6 +3587,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tyro"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/d6/7126f9e7de139632134d59b5d1972e93c610ee2cb13829e8f4f48f6613cb/tyro-1.0.13.tar.gz", hash = "sha256:731a90c9836b77fffe7c3fa0477ef2d3b6fa91252ddc0bb4d32dadd4fcc143d4", size = 489479, upload-time = "2026-04-14T18:21:52.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/4f/c43a0a8f0c66fd40a1d6cc47332a5a1d1043e9b331f7070ea701b91a7598/tyro-1.0.13-py3-none-any.whl", hash = "sha256:a0bdb8462c551dd84fc00a76916ce4d37e879c84eefaf34e2165312407cc6c09", size = 185221, upload-time = "2026-04-14T18:21:54.328Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Change train.py to accept various arguments and to allow job submission via SLURM.
For example, to submit a new training job with the `mnist_example` config with one small replacement:
```bash
uv run src/prox_lora/train.py submit mnist_example --replace trainer.max_epochs 1
```

(see DEFAULT_SLURM_CONFIG in train.py and see `uv run src/prox_lora/train.py --help`)

The directory structure changed a little bit, now its `runs/config_name/r42` instead of `checkpoints/config_name/version_42`.